### PR TITLE
Update to Boost 1.83

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - g++-8
 
   - os: linux
@@ -34,7 +34,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - g++-8
 
   - os: linux
@@ -50,7 +50,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - g++-8
 
   - os: linux
@@ -66,7 +66,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - g++-8
 
   - os: linux
@@ -83,7 +83,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - clang++-6.0
           - g++-8
 
@@ -101,7 +101,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - clang++-6.0
           - g++-8
 
@@ -119,7 +119,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - clang++-6.0
           - g++-8
 
@@ -137,7 +137,7 @@ matrix:
           - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - libssl-dev
-          - boost1.70
+          - boost1.83
           - clang++-6.0
           - g++-8
 

--- a/BeastHttp/include/http/base/impl/cb.hxx
+++ b/BeastHttp/include/http/base/impl/cb.hxx
@@ -4,6 +4,7 @@
 #include <http/base/config.hxx>
 
 #include <functional>
+#include <string>
 
 namespace _0xdead4ead {
 namespace http {
@@ -151,7 +152,7 @@ const_iterator<Session, Entry, Container>::const_iterator(
       cont_end_iter_{container.end()},
       request_{request},
       session_flesh_{flesh},
-      current_target_{request_.target().to_string()}
+      current_target_{std::string(request_.target())}
 {
     if (container.size() > 1)
         skip_target();

--- a/BeastHttp/include/http/base/impl/request_processor.hxx
+++ b/BeastHttp/include/http/base/impl/request_processor.hxx
@@ -43,7 +43,7 @@ request_processor<Session>::provide(
 
             for (auto __it_value = resource_map.cbegin();
                  __it_value != resource_map.cend(); ++__it_value) {
-                if (regex_.match(__it_value->first, target.to_string())) {
+                if (regex_.match(__it_value->first, std::string(target))) {
                     auto& storage = const_cast<storage_type&>(__it_value->second);
 
                     this->execute(request, _flesh, storage);
@@ -56,7 +56,7 @@ request_processor<Session>::provide(
     if (resource_map_ and not invoked)
         for (auto __it_value = resource_map_->begin();
              __it_value != resource_map_->end(); ++__it_value) {
-            if (regex_.match(__it_value->first, target.to_string())) {
+            if (regex_.match(__it_value->first, std::string(target))) {
                 auto& storage = const_cast<storage_type&>(__it_value->second);
 
                 this->execute(request, _flesh, storage);

--- a/BeastHttp/include/http/base/request_processor.hxx
+++ b/BeastHttp/include/http/base/request_processor.hxx
@@ -2,6 +2,7 @@
 #define BEASTHTTP_BASE_REQUEST_PROCESSOR_HXX
 
 #include <http/base/traits.hxx>
+#include <string>
 
 #include <memory>
 

--- a/BeastHttp/include/http/base/strand_stream.hxx
+++ b/BeastHttp/include/http/base/strand_stream.hxx
@@ -9,16 +9,7 @@ namespace _0xdead4ead {
 namespace http {
 namespace base {
 
-struct strand_stream :
-        boost::asio::strand<boost::asio::system_timer::executor_type>
-{
-    using asio_type = boost::asio::strand<boost::asio::system_timer::executor_type>;
-
-    strand_stream(const boost::asio::system_timer::executor_type& executor)
-        : asio_type(executor)
-    {
-    }
-};
+using strand_stream = boost::asio::strand<boost::asio::system_timer::executor_type>;
 
 } // namespace base
 } // namespace http

--- a/BeastHttp/include/http/common/detect.hxx
+++ b/BeastHttp/include/http/common/detect.hxx
@@ -33,13 +33,13 @@ template</*Message's buffer*/
          /*On timer expired handler holder*/
          template<typename> class OnTimer = std::function>
 class detect : public std::enable_shared_from_this<detect<BEASTHTTP_COMMON_DETECT_TMPL_ATTRIBUTES>>,
-        private base::strand_stream, base::detect<base::strand_stream::asio_type>, boost::asio::coroutine
+        private base::strand_stream, base::detect<base::strand_stream>, boost::asio::coroutine
 {
 public:
 
     using self_type = detect;
 
-    using base_type = base::detect<base::strand_stream::asio_type>;
+    using base_type = base::detect<base::strand_stream>;
 
     using protocol_type = Protocol;
 
@@ -47,7 +47,7 @@ public:
 
     using buffer_type = Buffer;
 
-    using timer_type = base::timer<Timer, base::strand_stream::asio_type>;
+    using timer_type = base::timer<Timer, base::strand_stream>;
 
     using duration_type = typename timer_type::duration_type;
 

--- a/BeastHttp/include/http/param.hxx
+++ b/BeastHttp/include/http/param.hxx
@@ -6,6 +6,7 @@
 
 #include <tuple>
 #include <mutex>
+#include <string>
 
 #include <boost/lexical_cast.hpp>
 
@@ -17,7 +18,7 @@
         shared_block_p_->cur_pos_cb_ = shared_block_p_->regex_pack.size() - 1; \
     } \
     std::smatch what; \
-    const auto& target = request.target().to_string(); \
+    const auto& target = std::string(request.target()); \
     if (shared_block_p_->regex_.match( \
                 *(shared_block_p_->rp_iter_), target, what)) \
         for (size_t i = 1; i < what.size(); i++) \
@@ -33,7 +34,7 @@
     if (shared_block_p_->rp_iter_ == shared_block_p_->regex_pack.cbegin()) \
         shared_block_p_->rp_iter_++; \
     std::smatch what; \
-    const auto& target = request.target().to_string(); \
+    const auto& target = std::string(request.target()); \
     if (shared_block_p_->regex_.match( \
                 *(shared_block_p_->rp_iter_), target, what)) \
         for (size_t i = 1; i < what.size(); i++) \

--- a/BeastHttp/include/http/reactor/session.hxx
+++ b/BeastHttp/include/http/reactor/session.hxx
@@ -137,11 +137,11 @@ public:
 
     using buffer_type = Buffer;
 
-    using connection_type = common::connection<Socket, base::strand_stream::asio_type>;
+    using connection_type = common::connection<Socket, base::strand_stream>;
 
     using socket_type = typename connection_type::socket_type;
 
-    using timer_type = base::timer<Timer, base::strand_stream::asio_type>;
+    using timer_type = base::timer<Timer, base::strand_stream>;
 
     using duration_type = typename timer_type::duration_type;
 

--- a/BeastHttp/include/http/reactor/ssl/session.hxx
+++ b/BeastHttp/include/http/reactor/ssl/session.hxx
@@ -147,13 +147,13 @@ public:
 
     using buffer_type = Buffer;
 
-    using connection_type = common::ssl::connection<Socket, base::strand_stream::asio_type>;
+    using connection_type = common::ssl::connection<Socket, base::strand_stream>;
 
     using socket_type = typename connection_type::socket_type;
 
     using ssl_stream_type = typename connection_type::ssl_stream_type;
 
-    using timer_type = base::timer<Timer, base::strand_stream::asio_type>;
+    using timer_type = base::timer<Timer, base::strand_stream>;
 
     using duration_type = typename timer_type::duration_type;
 

--- a/BeastHttp/src/CMakeLists.txt
+++ b/BeastHttp/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11)
 
 project(BeastHttp VERSION 3.0 LANGUAGES CXX)
 
-find_package(Boost 1.70 COMPONENTS system thread)
+find_package(Boost 1.83 COMPONENTS system thread)
 find_package(OpenSSL COMPONENTS SSL Crypto)
 
 set(BEASTHTTP_INCLUDE_PATH ${PROJECT_SOURCE_DIR}/../include)
@@ -12,6 +12,7 @@ set(BEASTHTTP_STATIC_DIR ${PROJECT_SOURCE_DIR}/../static)
 
 option(BEASTHTTP_USE_MAKE_SHARED "Allocate memory object with std::make_shared" ON)
 option(BEASTHTTP_BUILD_STATIC_LIBS "Build static lib for Boost.Asio/Boost.Beast" ON)
+option(BEASTHTTP_BUILD_EXAMPLES "Build example programs" OFF)
 
 configure_file (
   "${PROJECT_SOURCE_DIR}/cmake/version.hxx.in"
@@ -61,16 +62,18 @@ endif()
 
 file(GLOB_RECURSE BEASTHTTP_HEADS ${BEASTHTTP_INCLUDE_PATH}/*.hxx)
 
-add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor")
-if (OPENSSL_FOUND)
-    add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_ssl")
+if(BEASTHTTP_BUILD_EXAMPLES)
+    add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor")
+    if (OPENSSL_FOUND)
+        add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_ssl")
+    endif()
+    add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_cxx11")
+    add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_timers")
+    if (OPENSSL_FOUND)
+        add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_flex")
+    endif()
+    add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_sse")
 endif()
-add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_cxx11")
-add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_timers")
-if (OPENSSL_FOUND)
-    add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_flex")
-endif()
-add_subdirectory("${BEASTHTTP_EXAMPLES_DIR}/reactor_sse")
 enable_testing ()
 add_subdirectory("${BEASTHTTP_TESTS_DIR}/display")
 add_subdirectory("${BEASTHTTP_TESTS_DIR}/basic_router")

--- a/BeastHttp/src/tests/basic_router/CMakeLists.txt
+++ b/BeastHttp/src/tests/basic_router/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-find_package(Boost 1.70 COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost 1.83 COMPONENTS unit_test_framework REQUIRED)
 
 set(BEASTHTTP_BASIC_ROUTER_TEST_NAME basic_router)
 

--- a/BeastHttp/src/tests/chain_router/CMakeLists.txt
+++ b/BeastHttp/src/tests/chain_router/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-find_package(Boost 1.70 COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost 1.83 COMPONENTS unit_test_framework REQUIRED)
 
 set(BEASTHTTP_CHAIN_ROUTER_TEST_NAME chain_router)
 

--- a/BeastHttp/src/tests/display/CMakeLists.txt
+++ b/BeastHttp/src/tests/display/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-find_package(Boost 1.70 COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost 1.83 COMPONENTS unit_test_framework REQUIRED)
 
 set(BEASTHTTP_DISPLAY_TEST_NAME display)
 

--- a/BeastHttp/src/tests/param/CMakeLists.txt
+++ b/BeastHttp/src/tests/param/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-find_package(Boost 1.70 COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost 1.83 COMPONENTS unit_test_framework REQUIRED)
 
 set(BEASTHTTP_PARAM_TEST_NAME param)
 

--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@ Easy HTTP (Header-only) library implemented using minimum C++11 and Boost.Beast.
 
 # DEPENDENCIES
 
-* Boost Libraries >= 1.70.0
+* Boost Libraries >= 1.83.0
 * [`Boost.Asio`](https://github.com/boostorg/asio), [`Boost.Beast`](https://github.com/boostorg/beast/tree/develop)
 * [`OpenSSL`](https://github.com/openssl/openssl) (optional)
 * [`Boost.LexicalCast`](https://github.com/boostorg/lexical_cast) (optional)


### PR DESCRIPTION
## Summary
- require Boost 1.83 in CMake and tests
- make example building optional
- adjust string conversions for new Boost string_view
- update README and CI configuration
- fix compilation with Boost 1.83 and run unit tests

## Testing
- `cmake -S BeastHttp/src -B build -DBEASTHTTP_BUILD_EXAMPLES=OFF`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure`